### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://codedev.ms/sferg/88e9a024-33d2-4375-a629-5abd0102a5d0/049a4a82-f1fa-4f87-a9be-a50f91f4b040/_apis/work/boardbadge/8d1d6a74-0435-4415-9340-0a643910c63a)](https://codedev.ms/sferg/88e9a024-33d2-4375-a629-5abd0102a5d0/_boards/board/t/049a4a82-f1fa-4f87-a9be-a50f91f4b040/Microsoft.RequirementCategory)
 [![Board Status](https://dev.azure.com/sferg0325/faf8300b-43ed-4573-a61d-69e23d985e4f/8b2aae5d-ead6-4daf-aa93-0bfacf94f866/_apis/work/boardbadge/d22fd271-f0d3-48b9-8bcb-e7f2d2ed5528)](https://dev.azure.com/sferg0325/faf8300b-43ed-4573-a61d-69e23d985e4f/_boards/board/t/8b2aae5d-ead6-4daf-aa93-0bfacf94f866/Microsoft.RequirementCategory)
 # testing
 AB#1


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/sferg0325/faf8300b-43ed-4573-a61d-69e23d985e4f/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.